### PR TITLE
Add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,27 +47,6 @@ You can view progress of development in
 source files which can be redistributed under MIT license and included in this
 repository for testing purposes will be greatly appreciated.
 
-## Syntax feature requests
-
-All deprecated features (Mainly those from X2 format) are considered optional and
-priority to implement them will be assigned based on number of requests form community.
-
-If You needs support for syntax features which are not mentioned in
-`The Gerber Layer Format Specification. Revision 2023.03` (Available on
-[Ucamco's webpage](https://www.ucamco.com/files/downloads/file_en/456/gerber-layer-format-specification-revision-2023-03_en.pdf)
-and in
-[this repository](https://github.com/Argmaster/pygerber/blob/main/docs/gerber_specification/gerber-layer-format-specification-revision-2023-03_en.pdf))
-and this feature is not already listed in Support paragraph, please open a new Feature
-request issue.
-
-**Feature request Issue should contain:**
-
-- detailed description how requested feature works,
-- code samples for testing the feature,
-- reference images (only applies to features changing image look).
-
-**Requests which don't comply with those guidelines will be considered low priority.**
-
 ## Installation
 
 PyGerber can be installed with `pip` from PyPI:
@@ -82,7 +61,40 @@ Alternatively, it is also possible to install it directly from repository:
 pip install git+https://github.com/Argmaster/pygerber
 ```
 
-## Usage
+## Command line usage
+
+After installing `pygerber`, depending on your environment, it should become available
+in your command line:
+
+```bash
+pygerber --version
+```
+
+Output should be similar to one below **⇩**, where `x.y.z` should match version of
+PyGerber installed.
+
+```
+$ pygerber --version
+pygerber, version x.y.z
+```
+
+Use `--help` to display help messages with lists of subcommands and subcommand options:
+
+```
+pygerber raster-2d --help
+```
+
+To render 2D PNG image of some gerber file you can simply use:
+
+```
+pygerber raster-2d gerber-source.grb
+```
+
+Image will be saved to `output.png` in current working directory.
+
+![example_pcb_image](https://github.com/Argmaster/pygerber/assets/56170852/9bca28bf-8aa6-4215-aac1-62c386490485)
+
+## API usage
 
 PyGerber offers a high-level API that simplifies the process of rendering Gerber files.
 Whether you're looking to save the rendered output to a file or directly into a buffer,
@@ -439,6 +451,27 @@ Supported **DEPRECATED** Gerber features:
 - [ ] Image mirroring
 
 **IMPORTANT** This feature list is incomplete, it will get longer over time ...
+
+## Syntax feature requests
+
+All deprecated features (Mainly those from X2 format) are considered optional and
+priority to implement them will be assigned based on number of requests form community.
+
+If You needs support for syntax features which are not mentioned in
+`The Gerber Layer Format Specification. Revision 2023.03` (Available on
+[Ucamco's webpage](https://www.ucamco.com/files/downloads/file_en/456/gerber-layer-format-specification-revision-2023-03_en.pdf)
+and in
+[this repository](https://github.com/Argmaster/pygerber/blob/main/docs/gerber_specification/gerber-layer-format-specification-revision-2023-03_en.pdf))
+and this feature is not already listed in Support paragraph, please open a new Feature
+request issue.
+
+**Feature request Issue should contain:**
+
+- detailed description how requested feature works,
+- code samples for testing the feature,
+- reference images (only applies to features changing image look).
+
+**Requests which don't comply with those guidelines will be considered low priority.**
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ pygments = "^2.15.1"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.poetry.scripts]
+pygerber = "pygerber.__main__:main"
 
 [tool.poe.tasks]
 # -------------------------------------------------------------------------------------

--- a/src/pygerber/__main__.py
+++ b/src/pygerber/__main__.py
@@ -1,0 +1,8 @@
+"""Command line interface."""
+
+from __future__ import annotations
+
+from pygerber.console.commands import main
+
+if __name__ == "__main__":
+    main()

--- a/src/pygerber/console/commands.py
+++ b/src/pygerber/console/commands.py
@@ -1,0 +1,97 @@
+"""Command line commands of PyGerber."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, TextIO
+
+import click
+
+import pygerber
+from pygerber.console.raster_2d_style import (
+    STYLE_TO_COLOR_SCHEME,
+    get_color_scheme_from_style,
+)
+from pygerber.gerberx3.api import Rasterized2DLayer, Rasterized2DLayerParams
+
+
+@click.group("pygerber")
+@click.version_option(version=pygerber.__version__)
+def main() -> None:
+    """Command line interface of PyGerber, python implementation of Gerber X3/X2
+    standard with 2D rendering engine.
+    """
+
+
+@main.command("raster-2d")
+@click.argument("source", type=click.File())
+@click.option(
+    "-s",
+    "--style",
+    default="copper",
+    type=click.Choice(list(STYLE_TO_COLOR_SCHEME.keys()), case_sensitive=False),
+    help="Color style of the rendered image. When style is 'custom' then option "
+    "`--custom` must also be provided. Default is 'copper'.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=Path,
+    default="output.png",
+    help="Path to output file. File format will be inferred from extension, unless "
+    "`--format` is given. Default is 'output.png'",
+)
+@click.option(
+    "-f",
+    "--format",
+    "format_",
+    type=str,
+    default=None,
+    help="Output image format. Can be omitted, then format will be inferred from file"
+    "extension or be one of formats supported by Pillow.",
+)
+@click.option(
+    "-c",
+    "--custom",
+    type=str,
+    default=None,
+    help="String representing custom set of colors for rendering.\n"
+    "Custom color should be a single string consisting of 5 or 7 valid hexadecimal "
+    "colors separated with commas. Any color which can be parsed by RGBA type is "
+    "accepted.\n"
+    "Colors are assigned in order:"
+    "\n\n"
+    "- background_color\n\n"
+    "- clear_color\n\n"
+    "- solid_color\n\n"
+    "- clear_region_color\n\n"
+    "- solid_region_color\n\n"
+    "- debug_1_color (optional, by default #ABABAB)\n\n"
+    "- debug_2_color (optional, by default #7D7D7D)\n\n"
+    "\n\n"
+    'eg. `"000000,000000,FFFFFF,000000,FFFFFF"`',
+)
+def raster_2d(
+    source: TextIO,
+    style: str,
+    output: Path,
+    format_: Optional[str],
+    custom: Optional[str],
+) -> None:
+    """Render rasterized 2D image from Gerber X3/X2 SOURCE file.
+
+    SOURCE - A path to the Gerber file to render.
+
+    List of file formats supported by Pillow:
+    https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
+
+    \x08
+    RGBA type documentation:
+    https://argmaster.github.io/pygerber/latest/reference/pygerber/gerberx3/api/__init__.html#pygerber.common.rgba.RGBA.from_hex
+    """  # noqa: D301
+    gerber_code = source.read()
+    Rasterized2DLayer(
+        options=Rasterized2DLayerParams(
+            source_code=gerber_code,
+            colors=get_color_scheme_from_style(style, custom),
+        ),
+    ).render().save(output, format=format_)

--- a/src/pygerber/console/raster_2d_style.py
+++ b/src/pygerber/console/raster_2d_style.py
@@ -1,0 +1,92 @@
+"""Tool for converting style string to ColorScheme objects."""
+from __future__ import annotations
+
+from typing import Optional
+
+from pygerber.backend.rasterized_2d.color_scheme import ColorScheme
+from pygerber.common.rgba import RGBA
+
+CUSTOM_STYLE_OPTION = "custom"
+
+STYLE_TO_COLOR_SCHEME = {
+    "silk": ColorScheme.SILK,
+    "silk_alpha": ColorScheme.SILK_ALPHA,
+    "copper": ColorScheme.COPPER,
+    "copper_alpha": ColorScheme.COPPER_ALPHA,
+    "paste_mask": ColorScheme.PASTE_MASK,
+    "paste_mask_alpha": ColorScheme.PASTE_MASK_ALPHA,
+    "solder_mask": ColorScheme.SOLDER_MASK,
+    "solder_mask_alpha": ColorScheme.SOLDER_MASK_ALPHA,
+    "default_grayscale": ColorScheme.DEFAULT_GRAYSCALE,
+    "debug_1": ColorScheme.DEBUG_1,
+    CUSTOM_STYLE_OPTION: None,
+}
+"""Map of known color styles to ColorScheme objects."""
+
+
+def get_color_scheme_from_style(
+    style: str,
+    custom: Optional[str] = None,
+) -> ColorScheme:
+    """Convert style string to ColorScheme object.
+
+    Accepted values for style are any key from STYLE_TO_COLOR_SCHEME. When style is
+    'custom' then parameter custom must also be provided.
+    Custom color should be a single string consisting of 5 or 7 valid hexadecimal colors
+    separated with commas. Any color which can be parsed by RGBA type is accepted.
+    Colors are assigned in order:
+
+    - background_color
+    - clear_color
+    - solid_color
+    - clear_region_color
+    - solid_region_color
+    - debug_1_color (optional, by default #ABABAB)
+    - debug_2_color (optional, by default #7D7D7D)
+
+    eg. `"000000,000000,FFFFFF,000000,FFFFFF"`
+    """
+    if style == CUSTOM_STYLE_OPTION:
+        if custom is None:
+            msg = (
+                f"When style is {CUSTOM_STYLE_OPTION!r} custom have to be a valid "
+                "custom scheme."
+            )
+            raise TypeError(msg)
+        return _construct_custom_scheme(custom)
+
+    color_scheme = STYLE_TO_COLOR_SCHEME[style]
+    if color_scheme is None:
+        # Can't happen - option 'custom' is picked by if above.
+        raise TypeError
+
+    return color_scheme
+
+
+def _construct_custom_scheme(custom: str) -> ColorScheme:
+    (
+        background_color,
+        clear_color,
+        solid_color,
+        clear_region_color,
+        solid_region_color,
+        *debug_colors,
+    ) = custom.strip().split(",")
+
+    return ColorScheme(
+        background_color=RGBA.from_hex(background_color),
+        clear_color=RGBA.from_hex(clear_color),
+        solid_color=RGBA.from_hex(solid_color),
+        clear_region_color=RGBA.from_hex(clear_region_color),
+        solid_region_color=RGBA.from_hex(solid_region_color),
+        debug_1_color=(
+            RGBA.from_hex(debug_colors[0])
+            if len(debug_colors) > 0
+            else RGBA.from_hex("#ababab")
+        ),
+        debug_2_color=(
+            RGBA.from_hex(debug_colors[0])
+            if len(debug_colors) > 0
+            else RGBA.from_hex("#7d7d7d")
+        ),
+    )


### PR DESCRIPTION
## Command line usage

After installing `pygerber`, depending on your environment, it should become available
in your command line:

```bash
pygerber --version
```

Output should be similar to one below **⇩**, where `x.y.z` should match version of
PyGerber installed.

```
$ pygerber --version
pygerber, version x.y.z
```

Use `--help` to display help messages with lists of subcommands and subcommand options:

```
pygerber raster-2d --help
```

To render 2D PNG image of some gerber file you can simply use:

```
pygerber raster-2d gerber-source.grb
```

Image will be saved to `output.png` in current working directory.

![example_pcb_image](https://github.com/Argmaster/pygerber/assets/56170852/9bca28bf-8aa6-4215-aac1-62c386490485)
