### PR TITLE
Add virtual machine based on shapely library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
+## Pre-Release 3.0.0a3
+
+- Restored `pygerber_language_server` command.
+
 ## Pre-Release 3.0.0a2
 
 - Removed `Parser2` and related infrastructure. It was already replaced by `Parser` in

--- a/poetry.lock
+++ b/poetry.lock
@@ -2838,6 +2838,64 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "shapely"
+version = "2.0.6"
+description = "Manipulation and analysis of geometric objects"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "shapely-2.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29a34e068da2d321e926b5073539fd2a1d4429a2c656bd63f0bd4c8f5b236d0b"},
+    {file = "shapely-2.0.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c84c3f53144febf6af909d6b581bc05e8785d57e27f35ebaa5c1ab9baba13b"},
+    {file = "shapely-2.0.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ad2fae12dca8d2b727fa12b007e46fbc522148a584f5d6546c539f3464dccde"},
+    {file = "shapely-2.0.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3304883bd82d44be1b27a9d17f1167fda8c7f5a02a897958d86c59ec69b705e"},
+    {file = "shapely-2.0.6-cp310-cp310-win32.whl", hash = "sha256:3ec3a0eab496b5e04633a39fa3d5eb5454628228201fb24903d38174ee34565e"},
+    {file = "shapely-2.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:28f87cdf5308a514763a5c38de295544cb27429cfa655d50ed8431a4796090c4"},
+    {file = "shapely-2.0.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5aeb0f51a9db176da9a30cb2f4329b6fbd1e26d359012bb0ac3d3c7781667a9e"},
+    {file = "shapely-2.0.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9a7a78b0d51257a367ee115f4d41ca4d46edbd0dd280f697a8092dd3989867b2"},
+    {file = "shapely-2.0.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f32c23d2f43d54029f986479f7c1f6e09c6b3a19353a3833c2ffb226fb63a855"},
+    {file = "shapely-2.0.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3dc9fb0eb56498912025f5eb352b5126f04801ed0e8bdbd867d21bdbfd7cbd0"},
+    {file = "shapely-2.0.6-cp311-cp311-win32.whl", hash = "sha256:d93b7e0e71c9f095e09454bf18dad5ea716fb6ced5df3cb044564a00723f339d"},
+    {file = "shapely-2.0.6-cp311-cp311-win_amd64.whl", hash = "sha256:c02eb6bf4cfb9fe6568502e85bb2647921ee49171bcd2d4116c7b3109724ef9b"},
+    {file = "shapely-2.0.6-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cec9193519940e9d1b86a3b4f5af9eb6910197d24af02f247afbfb47bcb3fab0"},
+    {file = "shapely-2.0.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83b94a44ab04a90e88be69e7ddcc6f332da7c0a0ebb1156e1c4f568bbec983c3"},
+    {file = "shapely-2.0.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537c4b2716d22c92036d00b34aac9d3775e3691f80c7aa517c2c290351f42cd8"},
+    {file = "shapely-2.0.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fea108334be345c283ce74bf064fa00cfdd718048a8af7343c59eb40f59726"},
+    {file = "shapely-2.0.6-cp312-cp312-win32.whl", hash = "sha256:42fd4cd4834747e4990227e4cbafb02242c0cffe9ce7ef9971f53ac52d80d55f"},
+    {file = "shapely-2.0.6-cp312-cp312-win_amd64.whl", hash = "sha256:665990c84aece05efb68a21b3523a6b2057e84a1afbef426ad287f0796ef8a48"},
+    {file = "shapely-2.0.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:42805ef90783ce689a4dde2b6b2f261e2c52609226a0438d882e3ced40bb3013"},
+    {file = "shapely-2.0.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6d2cb146191a47bd0cee8ff5f90b47547b82b6345c0d02dd8b25b88b68af62d7"},
+    {file = "shapely-2.0.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3fdef0a1794a8fe70dc1f514440aa34426cc0ae98d9a1027fb299d45741c381"},
+    {file = "shapely-2.0.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c665a0301c645615a107ff7f52adafa2153beab51daf34587170d85e8ba6805"},
+    {file = "shapely-2.0.6-cp313-cp313-win32.whl", hash = "sha256:0334bd51828f68cd54b87d80b3e7cee93f249d82ae55a0faf3ea21c9be7b323a"},
+    {file = "shapely-2.0.6-cp313-cp313-win_amd64.whl", hash = "sha256:d37d070da9e0e0f0a530a621e17c0b8c3c9d04105655132a87cfff8bd77cc4c2"},
+    {file = "shapely-2.0.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fa7468e4f5b92049c0f36d63c3e309f85f2775752e076378e36c6387245c5462"},
+    {file = "shapely-2.0.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed5867e598a9e8ac3291da6cc9baa62ca25706eea186117034e8ec0ea4355653"},
+    {file = "shapely-2.0.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81d9dfe155f371f78c8d895a7b7f323bb241fb148d848a2bf2244f79213123fe"},
+    {file = "shapely-2.0.6-cp37-cp37m-win32.whl", hash = "sha256:fbb7bf02a7542dba55129062570211cfb0defa05386409b3e306c39612e7fbcc"},
+    {file = "shapely-2.0.6-cp37-cp37m-win_amd64.whl", hash = "sha256:837d395fac58aa01aa544495b97940995211e3e25f9aaf87bc3ba5b3a8cd1ac7"},
+    {file = "shapely-2.0.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c6d88ade96bf02f6bfd667ddd3626913098e243e419a0325ebef2bbd481d1eb6"},
+    {file = "shapely-2.0.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8b3b818c4407eaa0b4cb376fd2305e20ff6df757bf1356651589eadc14aab41b"},
+    {file = "shapely-2.0.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bbc783529a21f2bd50c79cef90761f72d41c45622b3e57acf78d984c50a5d13"},
+    {file = "shapely-2.0.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2423f6c0903ebe5df6d32e0066b3d94029aab18425ad4b07bf98c3972a6e25a1"},
+    {file = "shapely-2.0.6-cp38-cp38-win32.whl", hash = "sha256:2de00c3bfa80d6750832bde1d9487e302a6dd21d90cb2f210515cefdb616e5f5"},
+    {file = "shapely-2.0.6-cp38-cp38-win_amd64.whl", hash = "sha256:3a82d58a1134d5e975f19268710e53bddd9c473743356c90d97ce04b73e101ee"},
+    {file = "shapely-2.0.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:392f66f458a0a2c706254f473290418236e52aa4c9b476a072539d63a2460595"},
+    {file = "shapely-2.0.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eba5bae271d523c938274c61658ebc34de6c4b33fdf43ef7e938b5776388c1be"},
+    {file = "shapely-2.0.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7060566bc4888b0c8ed14b5d57df8a0ead5c28f9b69fb6bed4476df31c51b0af"},
+    {file = "shapely-2.0.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b02154b3e9d076a29a8513dffcb80f047a5ea63c897c0cd3d3679f29363cf7e5"},
+    {file = "shapely-2.0.6-cp39-cp39-win32.whl", hash = "sha256:44246d30124a4f1a638a7d5419149959532b99dfa25b54393512e6acc9c211ac"},
+    {file = "shapely-2.0.6-cp39-cp39-win_amd64.whl", hash = "sha256:2b542d7f1dbb89192d3512c52b679c822ba916f93479fa5d4fc2fe4fa0b3c9e8"},
+    {file = "shapely-2.0.6.tar.gz", hash = "sha256:997f6159b1484059ec239cacaa53467fd8b5564dabe186cd84ac2944663b0bf6"},
+]
+
+[package.dependencies]
+numpy = ">=1.14,<3"
+
+[package.extras]
+docs = ["matplotlib", "numpydoc (==1.1.*)", "sphinx", "sphinx-book-theme", "sphinx-remove-toctrees"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3147,12 +3205,13 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
-all = ["drawsvg", "lsprotocol", "pygls", "pygments"]
+all = ["drawsvg", "lsprotocol", "pygls", "pygments", "shapely"]
 language-server = ["lsprotocol", "pygls"]
 pygments = ["pygments"]
+shapely = ["shapely"]
 svg = ["drawsvg"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.13"
-content-hash = "faba48c9974cde3494ea0ed15150cf652dd123a2216ab5e82c99bc8bcd8671ac"
+content-hash = "84b66e73adffe72763a3d9b10f37b83f1e7566d4ed0064176087ca15b53caa14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygerber"
-version = "3.0.0a2"
+version = "3.0.0a3"
 description = "Parsing, formatting and rendering toolkit for Gerber X3 file format"
 authors = ["Krzysztof Wisniewski <argmaster.world@gmail.com>"]
 license = "MIT"
@@ -110,6 +110,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 pygerber = "pygerber.__main__:main"
+pygerber_language_server = "pygerber.gerber.language_server.__main__:main"
 
 [tool.poetry.plugins."pygments.lexers"]
 pygerber_docs_lexer = "pygerber.gerber.pygments:PyGerberDocsLexer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ lsprotocol = { version = "^2023.0.0a3", optional = true }
 drawsvg = { version = "^2.3.0", optional = true }
 typing-extensions = "^4.12.2"
 pygments = { version = "^2.18.0", optional = true }
+shapely = {version = "^2.0.6", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.6.1"
@@ -102,7 +103,8 @@ black = "^24.4.0"
 language_server = ["pygls", "lsprotocol"]
 svg = ["drawsvg"]
 pygments = ["pygments"]
-all = ["pygls", "lsprotocol", "drawsvg", "pygments"]
+shapely = ["shapely"]
+all = ["pygls", "lsprotocol", "drawsvg", "pygments", "shapely"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/pygerber/__init__.py
+++ b/src/pygerber/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "3.0.0a2"
+__version__ = "3.0.0a3"

--- a/src/pygerber/gerber/language_server/_server/hover/gerber.py
+++ b/src/pygerber/gerber/language_server/_server/hover/gerber.py
@@ -73,6 +73,7 @@ from pygerber.gerber.compiler import compile
 from pygerber.gerber.spec import rev_2024_05 as spec
 from pygerber.vm import render
 from pygerber.vm.pillow import PillowResult
+from pygerber.vm.types.style import Style
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -466,11 +467,14 @@ class GerberHoverCreator(AstVisitor):
             )
         nodes.extend(extra_commands)
 
-        rvmc = compile(File(nodes=nodes))
-        result = render(rvmc, dpmm=100)
+        bytecode = compile(File(nodes=nodes))
+        temp_result = render(bytecode, dpmm=1)
+
+        dpmm = 200 / temp_result.main_box.width
+        result = render(bytecode, dpmm=dpmm)
         assert isinstance(result, PillowResult)
 
-        tag = self._base64_image_tag(result.get_image())
+        tag = self._base64_image_tag(result.get_image(Style.presets.COPPER_ALPHA))
 
         self._print_line(tag)
 

--- a/src/pygerber/gerber/language_server/_server/hover/gerber.py
+++ b/src/pygerber/gerber/language_server/_server/hover/gerber.py
@@ -406,10 +406,10 @@ class GerberHoverCreator(AstVisitor):
 
     def _base64_image_tag(self, image: Image.Image) -> str:
         buffered = io.BytesIO()
-        image.save(buffered, format="JPEG")
+        image.save(buffered, format="PNG")
         image_bytes = buffered.getvalue()
         encoded_image = base64.b64encode(image_bytes).decode("utf-8")
-        return f'<p align="center"><img src="data:image/jpeg;base64,{encoded_image}" alt="Embedded Image" /></p>'
+        return f'<p align="center"><img src="data:image/png;base64,{encoded_image}" alt="Embedded Image" /></p>'
 
     def _visualize_draw_op(self, extra_commands: list[Node]) -> None:
         nodes: list[Node] = []

--- a/src/pygerber/gerber/language_server/status.py
+++ b/src/pygerber/gerber/language_server/status.py
@@ -22,7 +22,7 @@ def is_language_server_available() -> bool:
             _spec_lsprotocol = importlib.util.find_spec("lsprotocol")
 
         except (ImportError, ValueError):
-            return False
+            _IS_LANGUAGE_SERVER_AVAILABLE = False
 
         else:
             _IS_LANGUAGE_SERVER_AVAILABLE = (_spec_pygls is not None) and (

--- a/src/pygerber/gerber/pygments.py
+++ b/src/pygerber/gerber/pygments.py
@@ -15,16 +15,13 @@ def is_pygments_available() -> bool:
 
     if _IS_PYGMENTS_AVAILABLE is None:
         try:
-            _spec_pygls = importlib.util.find_spec("pygls")
-            _spec_lsprotocol = importlib.util.find_spec("lsprotocol")
+            _spec_pygments = importlib.util.find_spec("pygments")
 
         except (ImportError, ValueError):
-            return False
+            _IS_PYGMENTS_AVAILABLE = False
 
         else:
-            _IS_PYGMENTS_AVAILABLE = (_spec_pygls is not None) and (
-                _spec_lsprotocol is not None
-            )
+            _IS_PYGMENTS_AVAILABLE = _spec_pygments is not None
 
     return _IS_PYGMENTS_AVAILABLE
 

--- a/src/pygerber/vm/__init__.py
+++ b/src/pygerber/vm/__init__.py
@@ -22,13 +22,18 @@ __all__ = [
 
 
 def render(
-    rvmc: RVMC, *, backend: Literal["pillow"] = "pillow", **options: Any
+    rvmc: RVMC, *, backend: Literal["pillow", "shapely"] = "pillow", **options: Any
 ) -> Result:
     """Render RVMC code using given builder."""
     if backend == "pillow":
         from pygerber.vm.pillow import PillowVirtualMachine
 
         return PillowVirtualMachine(**options).run(rvmc)
+
+    if backend == "shapely":
+        from pygerber.vm.shapely import ShapelyVirtualMachine
+
+        return ShapelyVirtualMachine(**options).run(rvmc)
 
     msg = f"Backend '{backend}' is not supported."  # type: ignore[unreachable]
     raise NotImplementedError(msg)

--- a/src/pygerber/vm/pillow/vm.py
+++ b/src/pygerber/vm/pillow/vm.py
@@ -13,11 +13,14 @@ from PIL import Image, ImageDraw, ImageOps
 from pygerber.vm.commands import Arc, Line, PasteLayer, Shape
 from pygerber.vm.pillow.errors import DPMMTooSmallError
 from pygerber.vm.rvmc import RVMC
-from pygerber.vm.types.box import Box
-from pygerber.vm.types.errors import NoMainLayerError, PasteDeferredLayerNotAllowedError
-from pygerber.vm.types.layer_id import LayerID
-from pygerber.vm.types.style import Style
-from pygerber.vm.types.vector import Vector
+from pygerber.vm.types import (
+    Box,
+    LayerID,
+    NoMainLayerError,
+    PasteDeferredLayerNotAllowedError,
+    Style,
+    Vector,
+)
 from pygerber.vm.vm import (
     DeferredLayer,
     DrawCmdT,
@@ -36,7 +39,9 @@ MIN_SEGMENT_COUNT = 12
 
 
 class PillowResult(Result):
-    """Result of drawing commands."""
+    """The `PillowResult` class is a wrapper around items returned
+    `PillowVirtualMachine` class as a result of executing rendering instruction.
+    """
 
     def __init__(self, main_box: Box, image: Optional[Image.Image]) -> None:
         super().__init__(main_box)
@@ -138,13 +143,15 @@ class PillowDeferredLayer(DeferredLayer):
 
 
 class PillowVirtualMachine(VirtualMachine):
-    """Execute drawing commands using Pillow library."""
+    """The `PillowVirtualMachine` class is a concrete implementation of
+    `VirtualMachine` which uses Shapely library for rendering commands.
+    """
 
     def __init__(self, dpmm: int) -> None:
         super().__init__()
         self.dpmm = dpmm
         self.angle_length_to_segment_count = lambda angle_length: (
-            segment_count
+            int(segment_count)
             if (segment_count := angle_length * 2) > MIN_SEGMENT_COUNT
             else MIN_SEGMENT_COUNT
         )
@@ -223,7 +230,6 @@ class PillowVirtualMachine(VirtualMachine):
             raise DPMMTooSmallError(self.dpmm)
 
         angle_delta = angle_delta / segment_count
-
         assert angle_delta > 0
 
         angle_generator: Generator[float, None, None]

--- a/src/pygerber/vm/shapely/__init__.py
+++ b/src/pygerber/vm/shapely/__init__.py
@@ -1,0 +1,25 @@
+"""The `shapely` package contains concrete implementation of `VirtualMachine` using
+Shapely library.
+"""
+
+from __future__ import annotations
+
+from pygerber.vm.shapely.errors import (
+    ShapelyNotInstalledError,
+    ShapelyVirtualMachineError,
+)
+from pygerber.vm.shapely.vm import (
+    ShapelyDeferredLayer,
+    ShapelyEagerLayer,
+    ShapelyResult,
+    ShapelyVirtualMachine,
+)
+
+__all__ = [
+    "ShapelyVirtualMachine",
+    "ShapelyEagerLayer",
+    "ShapelyDeferredLayer",
+    "ShapelyResult",
+    "ShapelyNotInstalledError",
+    "ShapelyVirtualMachineError",
+]

--- a/src/pygerber/vm/shapely/errors.py
+++ b/src/pygerber/vm/shapely/errors.py
@@ -1,0 +1,21 @@
+"""`errors` module aggregates all exceptions related to the `ShapelyVirtualMachine`."""
+
+from __future__ import annotations
+
+from pygerber.vm.types.errors import VirtualMachineError
+
+
+class ShapelyVirtualMachineError(VirtualMachineError):
+    """Base class for all exceptions in the `ShapelyVirtualMachine`."""
+
+
+class ShapelyNotInstalledError(ShapelyVirtualMachineError):
+    """Raised when shapely package or other dependencies of `ShapelyVirtualMachine`
+    are not installed.
+
+    To install all dependencies of `ShapelyVirtualMachine`, run:
+
+    ```bash
+    pip install pygerber[shapely]
+    ```
+    """

--- a/src/pygerber/vm/shapely/vm.py
+++ b/src/pygerber/vm/shapely/vm.py
@@ -1,0 +1,319 @@
+"""The `vm` module contains concrete implementation of `VirtualMachine` using
+Shapely library.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import math
+import operator
+from contextlib import suppress
+from pathlib import Path
+from typing import Callable, Generator, Optional, Sequence, TextIO
+
+from pygerber.vm.commands import Arc, Line, Shape
+from pygerber.vm.rvmc import RVMC
+from pygerber.vm.shapely.errors import ShapelyNotInstalledError
+from pygerber.vm.types import Box, LayerID, NoMainLayerError, Style, Vector
+from pygerber.vm.vm import DeferredLayer, EagerLayer, Layer, Result, VirtualMachine
+
+FULL_ANGLE_DEGREES = 360
+
+DECREASE_ANGLE = (operator.sub, operator.gt)
+INCREASE_ANGLE = (operator.add, operator.lt)
+
+_IS_shapely_AVAILABLE: Optional[bool] = None
+
+
+def is_shapely_available() -> bool:
+    """Check if the language server feature is available."""
+    global _IS_shapely_AVAILABLE  # noqa: PLW0603
+
+    if _IS_shapely_AVAILABLE is None:
+        try:
+            _spec_pygls = importlib.util.find_spec("pygls")
+            _spec_lsprotocol = importlib.util.find_spec("lsprotocol")
+
+        except (ImportError, ValueError):
+            return False
+
+        else:
+            _IS_shapely_AVAILABLE = (_spec_pygls is not None) and (
+                _spec_lsprotocol is not None
+            )
+
+    return _IS_shapely_AVAILABLE
+
+
+with suppress(Exception):
+    import shapely as sh
+
+
+MIN_SEGMENT_COUNT = 12
+
+
+class ShapelyResult(Result):
+    """The `ShapelyResult` class is a wrapper around items returned
+    `ShapelyVirtualMachine` class as a result of executing rendering instruction.
+    """
+
+    def __init__(self, main_box: Box, shape: sh.geometry.base.BaseGeometry) -> None:
+        super().__init__(main_box)
+        if not is_shapely_available():
+            raise ShapelyNotInstalledError
+        self.shape = shape
+
+    def save_svg(
+        self,
+        destination: str | Path | TextIO,
+        color: Style = Style.presets.COPPER_ALPHA,
+    ) -> None:
+        """Save result to a file or buffer in SVG format.
+
+        Parameters
+        ----------
+        destination : str | Path | TextIO
+            `str` and `Path` objects are interpreted as file paths and opened with
+            truncation. `TextIO`-like (files, StringIO) objects are written to directly.
+        color : Style, optional
+            Color to use for SVG, background is ignored as it is always rendered as
+            empty space, so only foreground applies, by default
+            Style.presets.COPPER_ALPHA
+
+        """
+        if isinstance(destination, (str, Path)):
+            with Path(destination).open("w") as file:
+                self._dump_svg(file, color)
+
+        elif isinstance(destination, TextIO):
+            self._dump_svg(destination, color)
+
+    def _dump_svg(self, out: TextIO, color: Style) -> None:
+        out.write(
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+        )
+        if self.shape.is_empty:
+            out.write("/>")
+            return
+
+        xmin, ymin, xmax, ymax = self.shape.bounds
+
+        dx = xmax - xmin
+        dy = ymax - ymin
+        width = dx
+        height = dy
+
+        fill_color = color.foreground
+
+        view_box = f"{xmin} {ymin} {dx} {dy}"
+        transform = f"matrix(1,0,0,-1,0,{ymax + ymin})"
+
+        out.write(f'width="{width}" ')
+        out.write(f'height="{height}" ')
+        out.write(f'viewBox="{view_box}" ')
+        out.write('preserveAspectRatio="xMidYMid meet" ')
+        out.write(">")
+        out.write(
+            (
+                f'<g transform="{transform}">'
+                f"{self.shape.svg(scale_factor=0.0, fill_color=fill_color)}"
+                "</g>"
+            ).replace('stroke="#555555"', 'stroke="#00000000"')
+        )
+        out.write("</svg>")
+
+
+class ShapelyEagerLayer(EagerLayer):
+    """`ShapelyEagerLayer` class represents drawing space of known fixed size.
+
+    It is specifically used by `ShapelyEagerLayer` class.
+    """
+
+    def __init__(self, layer_id: LayerID, origin: Vector, box: Box) -> None:
+        super().__init__(layer_id, box, origin)
+        if not is_shapely_available():
+            raise ShapelyNotInstalledError
+        self.shape: sh.geometry.base.BaseGeometry = sh.MultiPolygon()
+
+
+class ShapelyDeferredLayer(DeferredLayer):
+    """`ShapelyDeferredLayer` class represents drawing space of size unknown at time of
+    creation of layer.
+
+    It is specifically used by `ShapelyDeferredLayer` class.
+    """
+
+
+class ShapelyVirtualMachine(VirtualMachine):
+    """The `ShapelyVirtualMachine` class is a concrete implementation of
+    `VirtualMachine` which uses Shapely library for rendering commands.
+    """
+
+    def __init__(
+        self,
+        angle_length_to_segment_count: Callable[[float], int] = lambda angle_length: (
+            int(math.log(abs(angle_length) + 1.2) * 100)
+        ),
+    ) -> None:
+        super().__init__()
+        self.angle_length_to_segment_count = angle_length_to_segment_count
+        if not is_shapely_available():
+            raise ShapelyNotInstalledError
+
+    @property
+    def layer(self) -> ShapelyEagerLayer:
+        """Get current layer."""
+        return super().layer  # type: ignore[return-value]
+
+    def create_eager_layer(self, layer_id: LayerID, box: Box, origin: Vector) -> Layer:
+        """Create new eager layer instances (factory method)."""
+        return ShapelyEagerLayer(layer_id, origin, box)
+
+    def create_deferred_layer(self, layer_id: LayerID, origin: Vector) -> Layer:
+        """Create new deferred layer instances (factory method)."""
+        return ShapelyDeferredLayer(layer_id, origin, commands=[])
+
+    def on_shape_eager(self, command: Shape) -> None:
+        """Visit shape command."""
+        points: list[tuple[float, float]] = []
+
+        for segment in command.commands:
+            if isinstance(segment, Line):
+                start = (segment.start.x, segment.start.y)
+                if len(points) == 0 or points[-1] != start:
+                    points.append(start)
+
+                end = (segment.end.x, segment.end.y)
+                points.append(end)
+
+            elif isinstance(segment, Arc):
+                start = (segment.start.x, segment.start.y)
+                if len(points) == 0 or points[-1] != start:
+                    points.append(start)
+
+                points.extend(self._calculate_arc_points(segment))
+                end = (segment.end.x, segment.end.y)
+
+                points.append(end)
+            else:
+                raise NotImplementedError
+
+        if points:
+            points.append(points[0])
+
+        self._add_polygon(points, is_negative=command.is_negative)
+
+    def _add_polygon(
+        self, points: Sequence[tuple[float, float]], *, is_negative: bool
+    ) -> None:
+        """Draw a polygon."""
+        layer = self.layer
+        x_offset = layer.origin.x
+        y_offset = layer.origin.y
+
+        polygon = sh.Polygon(
+            [
+                (
+                    x - x_offset,
+                    y - y_offset,
+                )
+                for (x, y) in points
+            ],
+        )
+        if is_negative:
+            self.layer.shape = self.layer.shape.difference(polygon)
+        else:
+            self.layer.shape = self.layer.shape.union(polygon)
+
+    def _calculate_arc_points(
+        self, command: Arc
+    ) -> Generator[tuple[float, float], None, None]:
+        """Calculate points on arc."""
+        start_angle = (
+            command.get_relative_start_point().angle_between(
+                Vector.unit.x,
+            )
+            % 360
+        )
+        end_angle = (
+            command.get_relative_end_point().angle_between(
+                Vector.unit.x,
+            )
+            % 360
+        )
+        assert start_angle >= 0
+        assert end_angle >= 0
+
+        assert start_angle < FULL_ANGLE_DEGREES
+        assert end_angle < FULL_ANGLE_DEGREES
+
+        angle_delta = abs(start_angle - end_angle)
+        angle_length = (angle_delta / 360) * (command.get_radius() * 2 * math.pi)
+        segment_count = self.angle_length_to_segment_count(angle_length)
+
+        angle_delta = angle_delta / segment_count
+        assert angle_delta > 0
+
+        angle_generator: Generator[float, None, None]
+
+        if start_angle <= end_angle:
+            if command.clockwise:
+                end_angle -= FULL_ANGLE_DEGREES
+                angle_generator = self._generate_arc_angles(
+                    start_angle, end_angle, angle_delta, *DECREASE_ANGLE
+                )
+            else:
+                angle_generator = self._generate_arc_angles(
+                    start_angle, end_angle, angle_delta, *INCREASE_ANGLE
+                )
+        elif command.clockwise:
+            angle_generator = self._generate_arc_angles(
+                start_angle, end_angle, angle_delta, *DECREASE_ANGLE
+            )
+        else:
+            end_angle += FULL_ANGLE_DEGREES
+            angle_generator = self._generate_arc_angles(
+                start_angle, end_angle, angle_delta, *INCREASE_ANGLE
+            )
+
+        radius = command.get_radius()
+
+        yield command.start.xy
+
+        for angle in angle_generator:
+            offset_vector = Vector(
+                x=radius * math.cos(math.radians(angle)),
+                y=radius * math.sin(math.radians(angle)),
+            )
+
+            yield (command.center + offset_vector).xy
+
+        yield command.end.xy
+
+    def _generate_arc_angles(
+        self,
+        start: float,
+        end: float,
+        delta: float,
+        apply_delta: Callable[[float, float], float],
+        compare_angles: Callable[[float, float], bool],
+    ) -> Generator[float, None, None]:
+        current_angle = start
+        while compare_angles(current_angle, end):
+            yield current_angle
+            current_angle = apply_delta(current_angle, delta)
+        yield end
+
+    def run(self, rvmc: RVMC) -> ShapelyResult:
+        """Execute all commands."""
+        super().run(rvmc)
+
+        layer = self._layers.get(self.MAIN_LAYER_ID, None)
+
+        if layer is None:
+            raise NoMainLayerError
+
+        assert isinstance(layer, ShapelyEagerLayer)
+        return ShapelyResult(layer.box, layer.shape)

--- a/src/pygerber/vm/shapely/vm.py
+++ b/src/pygerber/vm/shapely/vm.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Callable, Generator, Optional, Sequence, TextIO
 
 import numpy as np
-from shapely import Polygon
 
 from pygerber.vm.commands import Arc, Line, Shape
 from pygerber.vm.commands.paste import PasteLayer
@@ -37,16 +36,13 @@ def is_shapely_available() -> bool:
 
     if _IS_shapely_AVAILABLE is None:
         try:
-            _spec_pygls = importlib.util.find_spec("pygls")
-            _spec_lsprotocol = importlib.util.find_spec("lsprotocol")
+            _spec_shapely = importlib.util.find_spec("shapely")
 
         except (ImportError, ValueError):
-            return False
+            _IS_shapely_AVAILABLE = False
 
         else:
-            _IS_shapely_AVAILABLE = (_spec_pygls is not None) and (
-                _spec_lsprotocol is not None
-            )
+            _IS_shapely_AVAILABLE = _spec_shapely is not None
 
     return _IS_shapely_AVAILABLE
 
@@ -143,7 +139,7 @@ class ShapelyEagerLayer(EagerLayer):
         if not is_shapely_available():
             raise ShapelyNotInstalledError
 
-        self.shape: list[Polygon] = []
+        self.shape: list[sh.Polygon] = []
 
 
 class ShapelyDeferredLayer(DeferredLayer):
@@ -167,11 +163,11 @@ class ShapelyVirtualMachine(VirtualMachine):
         grid_size: Optional[float] = None,
     ) -> None:
         super().__init__()
-        self.angle_length_to_segment_count = angle_length_to_segment_count
-        self.grid_size = grid_size
-
         if not is_shapely_available():
             raise ShapelyNotInstalledError
+
+        self.angle_length_to_segment_count = angle_length_to_segment_count
+        self.grid_size = grid_size
 
     @property
     def layer(self) -> ShapelyEagerLayer:

--- a/src/pygerber/vm/types/__init__.py
+++ b/src/pygerber/vm/types/__init__.py
@@ -15,6 +15,7 @@ from pygerber.vm.types.errors import (
 )
 from pygerber.vm.types.layer_id import LayerID
 from pygerber.vm.types.matrix import Matrix3x3
+from pygerber.vm.types.style import Style
 from pygerber.vm.types.vector import Vector
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "LayerAlreadyExistsError",
     "PasteDeferredLayerNotAllowedError",
     "NoMainLayerError",
+    "Style",
 ]

--- a/src/pygerber/vm/vm.py
+++ b/src/pygerber/vm/vm.py
@@ -25,7 +25,11 @@ DrawCmdT: TypeAlias = Union[Shape, PasteLayer]
 
 
 class Result:
-    """Result of drawing."""
+    """The `Result` class is a wrapper around items returned from virtual machine.
+
+    It is used as a base class for results returned from vms extending `VirtualMachine`
+    class.
+    """
 
     main_box: Box
 

--- a/test/benchmark/shapely_fc_poly_top.py
+++ b/test/benchmark/shapely_fc_poly_top.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import cProfile
+from pathlib import Path
+from typing import cast
+
+from pygerber.gerber.compiler import compile
+from pygerber.gerber.parser import parse
+from pygerber.vm import render
+from pygerber.vm.shapely import ShapelyResult
+from test.assets.gerberx3.FcPoly_Test import FcPoly_Test
+
+THIS_FILE = Path(__file__)
+THIS_DIRECTORY = THIS_FILE.parent
+
+
+def benchmark() -> None:
+    ast = parse(FcPoly_Test.top.load())
+    rvmc = compile(ast)
+    result = cast(ShapelyResult, render(rvmc, backend="shapely"))
+    result.save_svg(THIS_DIRECTORY / "#FcPoly_bottom.svg")
+
+
+if __name__ == "__main__":
+    cProfile.run("benchmark()", THIS_FILE.with_suffix(".prof").as_posix())

--- a/test/benchmark/shapely_fc_poly_top.sh
+++ b/test/benchmark/shapely_fc_poly_top.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/time -v python -m test.benchmark.shapely_fc_poly_top

--- a/test/e2e/gerberx3/.gitignore
+++ b/test/e2e/gerberx3/.gitignore
@@ -1,1 +1,1 @@
-test_pillow.py.output/
+*.py.output/

--- a/test/e2e/gerberx3/test_shapely.py
+++ b/test/e2e/gerberx3/test_shapely.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from pygerber.gerber.ast.nodes.file import File
+from pygerber.gerber.compiler import compile
+from pygerber.gerber.parser import parse
+from pygerber.vm.shapely.vm import ShapelyResult, ShapelyVirtualMachine
+from test.assets.asset import GerberX3Asset
+from test.assets.generated.macro import (
+    get_custom_circle_local_2_0,
+    get_custom_circle_local_2_0_ring_rot_30,
+    get_custom_circle_local_2_0_rot_30,
+)
+from test.assets.gerberx3.A64_OLinuXino_rev_G import A64_OlinuXino_Rev_G
+from test.assets.gerberx3.FcPoly_Test import FcPoly_Test
+from test.assets.gerberx3.flashes import Flashes
+from test.assets.gerberx3.flashes_with_transform import FlashesWithTransform
+from test.assets.gerberx3.macro.codes import MacroCodeAssets
+from test.assets.gerberx3.ucamco import GerberSpecExampleAssets
+
+THIS_FILE = Path(__file__)
+THIS_DIRECTORY = THIS_FILE.parent
+
+OUTPUT_DUMP_DIRECTORY = THIS_DIRECTORY / f"{THIS_FILE.name}.output"
+OUTPUT_DUMP_DIRECTORY.mkdir(exist_ok=True)
+
+
+class ShapelyRenderE2E:
+    def _render(self, source: GerberX3Asset) -> ShapelyResult:
+        ast = parse(source.load())
+        return self._render_ast(ast)
+
+    def _render_ast(self, ast: File) -> ShapelyResult:
+        rvmc = compile(ast)
+        return ShapelyVirtualMachine().run(rvmc)
+
+    def _save(self, result: ShapelyResult) -> None:
+        caller_frame = inspect.stack()[1]
+        caller_function_name = caller_frame.function
+        caller_self = caller_frame.frame.f_locals.get("self")
+
+        if caller_self is not None:
+            dump_directory = OUTPUT_DUMP_DIRECTORY / caller_self.__class__.__name__
+            dump_directory.mkdir(exist_ok=True, parents=True)
+        else:
+            dump_directory = OUTPUT_DUMP_DIRECTORY
+
+        result.save_svg((dump_directory / caller_function_name).with_suffix(".svg"))
+
+
+class TestOLinuXinoRevG(ShapelyRenderE2E):
+    @pytest.mark.skip("Poor performance skip")
+    def test_bottom_copper(self) -> None:
+        result = self._render(A64_OlinuXino_Rev_G.A64_OlinuXino_Rev_G_B_Cu)
+        self._save(result)
+
+    def test_bottom_mask(self) -> None:
+        result = self._render(A64_OlinuXino_Rev_G.A64_OlinuXino_Rev_G_B_Mask)
+        self._save(result)
+
+    def test_bottom_paste(self) -> None:
+        result = self._render(A64_OlinuXino_Rev_G.A64_OlinuXino_Rev_G_B_Paste)
+        self._save(result)
+
+
+class TestFcPolyTest(ShapelyRenderE2E):
+    def test_bottom(self) -> None:
+        result = self._render(FcPoly_Test.bottom)
+        self._save(result)
+
+    def test_top(self) -> None:
+        result = self._render(FcPoly_Test.top)
+        self._save(result)
+
+
+class TestFlashes(ShapelyRenderE2E):
+    def test_00_circle_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_00_circle_h_4_grb)
+        self._save(result)
+
+    def test_00_circle_h_4_tbh_grb(self) -> None:
+        result = self._render(Flashes.asset_00_circle_h_4_tbh_grb)
+        self._save(result)
+
+    def test_00_circle_4_grb(self) -> None:
+        result = self._render(Flashes.asset_00_circle_4_grb)
+        self._save(result)
+
+    def test_01_rectangle_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_01_rectangle_h_4_grb)
+        self._save(result)
+
+    def test_01_rectangle_v_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_01_rectangle_v_h_4_grb)
+        self._save(result)
+
+    def test_01_rectangle_v_4_grb(self) -> None:
+        result = self._render(Flashes.asset_01_rectangle_v_4_grb)
+        self._save(result)
+
+    def test_01_rectangle_4_grb(self) -> None:
+        result = self._render(Flashes.asset_01_rectangle_4_grb)
+        self._save(result)
+
+    def test_02_obround_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_02_obround_h_4_grb)
+        self._save(result)
+
+    def test_02_obround_v_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_02_obround_v_h_4_grb)
+        self._save(result)
+
+    def test_02_obround_v_4_grb(self) -> None:
+        result = self._render(Flashes.asset_02_obround_v_4_grb)
+        self._save(result)
+
+    def test_02_obround_4_grb(self) -> None:
+        result = self._render(Flashes.asset_02_obround_4_grb)
+        self._save(result)
+
+    def test_03_polygon3_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_03_polygon3_h_4_grb)
+        self._save(result)
+
+    def test_03_polygon3_r90_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_03_polygon3_r90_h_4_grb)
+        self._save(result)
+
+    def test_03_polygon3_r90_4_grb(self) -> None:
+        result = self._render(Flashes.asset_03_polygon3_r90_4_grb)
+        self._save(result)
+
+    def test_03_polygon3_4_grb(self) -> None:
+        result = self._render(Flashes.asset_03_polygon3_4_grb)
+        self._save(result)
+
+    def test_04_polygon6_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_04_polygon6_h_4_grb)
+        self._save(result)
+
+    def test_04_polygon6_r90_h_4_grb(self) -> None:
+        result = self._render(Flashes.asset_04_polygon6_r90_h_4_grb)
+        self._save(result)
+
+    def test_04_polygon6_r90_4_grb(self) -> None:
+        result = self._render(Flashes.asset_04_polygon6_r90_4_grb)
+        self._save(result)
+
+    def test_04_polygon6_4_grb(self) -> None:
+        result = self._render(Flashes.asset_04_polygon6_4_grb)
+        self._save(result)
+
+    def test_05_circle_h_rectangle_h_obround_h_triangle_h_grb(self) -> None:
+        result = self._render(
+            Flashes.asset_05_circle_h_rectangle_h_obround_h_triangle_h_grb
+        )
+        self._save(result)
+
+
+class TestFlashesWithTransform(ShapelyRenderE2E):
+    def test_rectangle_rotation_30(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_30)
+        self._save(result)
+
+    def test_rectangle_rotation_45(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_45)
+        self._save(result)
+
+    def test_rectangle_rotation_60(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_60)
+        self._save(result)
+
+    def test_rectangle_rotation_90(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_90)
+        self._save(result)
+
+    def test_rectangle_rotation_45_mirror_x(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_45_mirror_x)
+        self._save(result)
+
+    def test_rectangle_rotation_45_mirror_y(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_45_mirror_y)
+        self._save(result)
+
+    def test_rectangle_rotation_45_mirror_xy(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_45_mirror_xy)
+        self._save(result)
+
+    def test_rectangle_rotation_30_mirror_x(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_30_mirror_x)
+        self._save(result)
+
+    def test_rectangle_rotation_30_mirror_y(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_30_mirror_y)
+        self._save(result)
+
+    def test_rectangle_rotation_30_mirror_xy(self) -> None:
+        result = self._render(FlashesWithTransform.rectangle_rotation_30_mirror_xy)
+        self._save(result)
+
+
+class TestGeneratedMacro(ShapelyRenderE2E):
+    def test_custom_circle_local_2_0(self) -> None:
+        result = self._render_ast(get_custom_circle_local_2_0())
+        self._save(result)
+
+    def test_custom_circle_local_2_0_rot_30(self) -> None:
+        result = self._render_ast(get_custom_circle_local_2_0_rot_30())
+        self._save(result)
+
+    def test_custom_circle_local_2_0_ring_rot_30(self) -> None:
+        result = self._render_ast(get_custom_circle_local_2_0_ring_rot_30())
+        self._save(result)
+
+
+class TestMacroCodes(ShapelyRenderE2E):
+    def test_code_1(self) -> None:
+        result = self._render(MacroCodeAssets.code_1)
+        self._save(result)
+
+    def test_code_2(self) -> None:
+        result = self._render(MacroCodeAssets.code_2)
+        self._save(result)
+
+    def test_code_20(self) -> None:
+        result = self._render(MacroCodeAssets.code_20)
+        self._save(result)
+
+    def test_code_4_0(self) -> None:
+        result = self._render(MacroCodeAssets.code_4_0)
+        self._save(result)
+
+    def test_code_4_1(self) -> None:
+        result = self._render(MacroCodeAssets.code_4_1)
+        self._save(result)
+
+    def test_code_5(self) -> None:
+        result = self._render(MacroCodeAssets.code_5)
+        self._save(result)
+
+    def test_code_6(self) -> None:
+        result = self._render(MacroCodeAssets.code_6)
+        self._save(result)
+
+    def test_code_7_0(self) -> None:
+        result = self._render(MacroCodeAssets.code_7_0)
+        self._save(result)
+
+    def test_code_7_1(self) -> None:
+        result = self._render(MacroCodeAssets.code_7_1)
+        self._save(result)
+
+    def test_code_7_2(self) -> None:
+        result = self._render(MacroCodeAssets.code_7_2)
+        self._save(result)
+
+    def test_code_7_3(self) -> None:
+        result = self._render(MacroCodeAssets.code_7_3)
+        self._save(result)
+
+    def test_code_21(self) -> None:
+        result = self._render(MacroCodeAssets.code_21)
+        self._save(result)
+
+    def test_code_22(self) -> None:
+        result = self._render(MacroCodeAssets.code_22)
+        self._save(result)
+
+
+class TestGerberSpecExampleAssets(ShapelyRenderE2E):
+    def test_asset_2_1(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_2_1)
+        self._save(result)
+
+    def test_asset_2_11_1(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_2_11_1)
+        self._save(result)
+
+    def test_asset_2_11_2(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_2_11_2)
+        self._save(result)
+
+    def test_asset_4_4_6(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_4_6)
+        self._save(result)
+
+    def test_asset_4_9_1(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_9_1)
+        self._save(result)
+
+    def test_asset_4_9_6(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_9_6)
+        self._save(result)
+
+    def test_asset_4_9_6_0(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_9_6_0)
+        self._save(result)
+
+    def test_asset_4_9_6_1(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_9_6_1)
+        self._save(result)
+
+    def test_asset_4_9_6_2(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_9_6_2)
+        self._save(result)
+
+    def test_asset_4_9_6_3(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_9_6_3)
+        self._save(result)
+
+    def test_asset_4_10_4_1(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_10_4_1)
+        self._save(result)
+
+    def test_asset_4_10_4_2(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_10_4_2)
+        self._save(result)
+
+    def test_asset_4_10_4_4(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_10_4_4)
+        self._save(result)
+
+    def test_asset_4_10_4_7(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_10_4_7)
+        self._save(result)
+
+    def test_asset_4_10_4_8(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_10_4_8)
+        self._save(result)
+
+    def test_asset_4_10_4_9(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_10_4_9)
+        self._save(result)
+
+    def test_asset_4_11_4(self) -> None:
+        result = self._render(GerberSpecExampleAssets.asset_4_11_4)
+        self._save(result)

--- a/test/e2e/gerberx3/test_shapely.py
+++ b/test/e2e/gerberx3/test_shapely.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
-
-import pytest
+from typing import Type
 
 from pygerber.gerber.ast.nodes.file import File
 from pygerber.gerber.compiler import compile
@@ -16,10 +15,16 @@ from test.assets.generated.macro import (
     get_custom_circle_local_2_0_rot_30,
 )
 from test.assets.gerberx3.A64_OLinuXino_rev_G import A64_OlinuXino_Rev_G
+from test.assets.gerberx3.arc.clockwise import ClockwiseArcAssets
+from test.assets.gerberx3.arc.counterclockwise import CounterClockwiseArcAssets
+from test.assets.gerberx3.ATMEGA328 import ATMEGA328Assets
 from test.assets.gerberx3.FcPoly_Test import FcPoly_Test
 from test.assets.gerberx3.flashes import Flashes
 from test.assets.gerberx3.flashes_with_transform import FlashesWithTransform
+from test.assets.gerberx3.KicadGerberX2 import KiCadGerberX2Assets
 from test.assets.gerberx3.macro.codes import MacroCodeAssets
+from test.assets.gerberx3.polarity_cutouts import PolarityCutouts
+from test.assets.gerberx3.step_and_repeat import StepAndRepeatAssets
 from test.assets.gerberx3.ucamco import GerberSpecExampleAssets
 
 THIS_FILE = Path(__file__)
@@ -53,7 +58,6 @@ class ShapelyRenderE2E:
 
 
 class TestOLinuXinoRevG(ShapelyRenderE2E):
-    @pytest.mark.skip("Poor performance skip")
     def test_bottom_copper(self) -> None:
         result = self._render(A64_OlinuXino_Rev_G.A64_OlinuXino_Rev_G_B_Cu)
         self._save(result)
@@ -271,6 +275,70 @@ class TestMacroCodes(ShapelyRenderE2E):
         self._save(result)
 
 
+class ArcSuite(ShapelyRenderE2E):
+    assets: Type[ClockwiseArcAssets] | Type[CounterClockwiseArcAssets]
+
+    def test_full(self) -> None:
+        result = self._render(self.assets.full)
+        self._save(result)
+
+    def test_bot_half(self) -> None:
+        result = self._render(self.assets.half_bot)
+        self._save(result)
+
+    def test_top_half(self) -> None:
+        result = self._render(self.assets.half_top)
+        self._save(result)
+
+    def test_left_half(self) -> None:
+        result = self._render(self.assets.half_left)
+        self._save(result)
+
+    def test_right_half(self) -> None:
+        result = self._render(self.assets.half_right)
+        self._save(result)
+
+    def test_quarter_bot_left(self) -> None:
+        result = self._render(self.assets.quarter_bot_left)
+        self._save(result)
+
+    def test_quarter_bot_right(self) -> None:
+        result = self._render(self.assets.quarter_bot_right)
+        self._save(result)
+
+    def test_quarter_top_left(self) -> None:
+        result = self._render(self.assets.quarter_top_left)
+        self._save(result)
+
+    def test_quarter_top_right(self) -> None:
+        result = self._render(self.assets.quarter_top_right)
+        self._save(result)
+
+    def test_three_fourth_bot_left(self) -> None:
+        result = self._render(self.assets.three_fourth_bot_left)
+        self._save(result)
+
+    def test_three_fourth_bot_right(self) -> None:
+        result = self._render(self.assets.three_fourth_bot_right)
+        self._save(result)
+
+    def test_three_fourth_top_left(self) -> None:
+        result = self._render(self.assets.three_fourth_top_left)
+        self._save(result)
+
+    def test_three_fourth_top_right(self) -> None:
+        result = self._render(self.assets.three_fourth_top_right)
+        self._save(result)
+
+
+class TestMqClockwiseArcs(ArcSuite):
+    assets = ClockwiseArcAssets
+
+
+class TestMqCounterClockwiseArcs(ArcSuite):
+    assets = CounterClockwiseArcAssets
+
+
 class TestGerberSpecExampleAssets(ShapelyRenderE2E):
     def test_asset_2_1(self) -> None:
         result = self._render(GerberSpecExampleAssets.asset_2_1)
@@ -338,4 +406,150 @@ class TestGerberSpecExampleAssets(ShapelyRenderE2E):
 
     def test_asset_4_11_4(self) -> None:
         result = self._render(GerberSpecExampleAssets.asset_4_11_4)
+        self._save(result)
+
+
+class TestATMEGA328(ShapelyRenderE2E):
+    def test_bottom_copper(self) -> None:
+        result = self._render(ATMEGA328Assets.bottom_copper)
+        self._save(result)
+
+    def test_bottom_mask(self) -> None:
+        result = self._render(ATMEGA328Assets.bottom_mask)
+        self._save(result)
+
+    def test_bottom_paste(self) -> None:
+        result = self._render(ATMEGA328Assets.bottom_paste)
+        self._save(result)
+
+    def test_bottom_silk(self) -> None:
+        result = self._render(ATMEGA328Assets.bottom_silk)
+        self._save(result)
+
+    def test_edge_cuts(self) -> None:
+        result = self._render(ATMEGA328Assets.edge_cuts)
+        self._save(result)
+
+    def test_top_copper(self) -> None:
+        result = self._render(ATMEGA328Assets.top_copper)
+        self._save(result)
+
+    def test_top_mask(self) -> None:
+        result = self._render(ATMEGA328Assets.top_mask)
+        self._save(result)
+
+    def test_top_paste(self) -> None:
+        result = self._render(ATMEGA328Assets.top_paste)
+        self._save(result)
+
+    def test_top_silk(self) -> None:
+        result = self._render(ATMEGA328Assets.top_silk)
+        self._save(result)
+
+
+class TestPolarityCutouts(ShapelyRenderE2E):
+    def test_sample(self) -> None:
+        result = self._render(PolarityCutouts.sample)
+        self._save(result)
+
+
+class TestKiCadGerberX2(ShapelyRenderE2E):
+    def test_bottom_copper(self) -> None:
+        result = self._render(KiCadGerberX2Assets.bottom_copper)
+        self._save(result)
+
+    def test_bottom_mask(self) -> None:
+        result = self._render(KiCadGerberX2Assets.bottom_mask)
+        self._save(result)
+
+    def test_edge_cuts(self) -> None:
+        result = self._render(KiCadGerberX2Assets.edge_cuts)
+        self._save(result)
+
+    def test_top_copper(self) -> None:
+        result = self._render(KiCadGerberX2Assets.top_copper)
+        self._save(result)
+
+    def test_top_mask(self) -> None:
+        result = self._render(KiCadGerberX2Assets.top_mask)
+        self._save(result)
+
+    def test_top_paste(self) -> None:
+        result = self._render(KiCadGerberX2Assets.top_paste)
+        self._save(result)
+
+    def test_top_silk(self) -> None:
+        result = self._render(KiCadGerberX2Assets.top_silk)
+        self._save(result)
+
+
+class TestStepAndRepeat(ShapelyRenderE2E):
+    def test_cr_x_3(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_x_3)
+        self._save(result)
+
+    def test_cr_x_6(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_x_6)
+        self._save(result)
+
+    def test_cr_y_3(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_y_3)
+        self._save(result)
+
+    def test_cr_y_6(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_y_6)
+        self._save(result)
+
+    def test_cr_xy_3_6(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_3_6)
+        self._save(result)
+
+    def test_cr_xy_6_6(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_6_6)
+        self._save(result)
+
+    # Rot 30
+
+    def test_cr_x_3_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_x_3_rot_30)
+        self._save(result)
+
+    def test_cr_x_6_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_x_6_rot_30)
+        self._save(result)
+
+    def test_cr_y_3_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_y_3_rot_30)
+        self._save(result)
+
+    def test_cr_y_6_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_y_6_rot_30)
+        self._save(result)
+
+    def test_cr_xy_3_6_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_3_6_rot_30)
+        self._save(result)
+
+    def test_cr_xy_6_6_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_6_6_rot_30)
+        self._save(result)
+
+    # Line
+
+    def test_cr_xy_2_2_line(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_2_2_line)
+        self._save(result)
+
+    def test_cr_xy_2_2_line_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_2_2_line_rot_30)
+        self._save(result)
+
+    # AB
+
+    def test_cr_xy_2_2_ab(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_2_2_ab)
+        self._save(result)
+
+    def test_cr_xy_2_2_ab_rot_30(self) -> None:
+        result = self._render(StepAndRepeatAssets.cr_xy_2_2_ab_rot_30)
         self._save(result)

--- a/test/gerberx3/common.py
+++ b/test/gerberx3/common.py
@@ -6,6 +6,7 @@ import fnmatch
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Generator,
@@ -13,6 +14,7 @@ from typing import (
     Iterable,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
     cast,
@@ -25,6 +27,9 @@ from filelock import FileLock
 from PIL import Image, ImageDraw
 
 from pygerber.gerber.api._enums import GERBER_EXTENSION_TO_FILE_TYPE_MAPPING
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 ASSET_PATH_BASE = "test/assets/gerberx3"
 
@@ -181,6 +186,9 @@ REFERENCE_ASSET_SHA = "fd3d59618be220fc5554e03de2b18e66009c30c9"
 REFERENCE_ASSETS_MANAGER = ReferenceAssetsManager(REFERENCE_ASSET_SHA)
 
 
+_RGBA_PIXEL: TypeAlias = Tuple[int, int, int, int]
+
+
 def highlight_differences(first: Image.Image, second: Image.Image) -> Image.Image:
     """
     Highlight the differences between two images.
@@ -197,8 +205,8 @@ def highlight_differences(first: Image.Image, second: Image.Image) -> Image.Imag
     draw = ImageDraw.Draw(diff_img)
     for x in range(max_width):
         for y in range(max_height):
-            r1, g1, b1, a1 = img1_centered.getpixel((x, y))
-            r2, g2, b2, a2 = img2_centered.getpixel((x, y))
+            r1, g1, b1, a1 = cast(_RGBA_PIXEL, img1_centered.getpixel((x, y)))
+            r2, g2, b2, a2 = cast(_RGBA_PIXEL, img2_centered.getpixel((x, y)))
             draw.point(
                 (x, y),
                 fill=(

--- a/test/test_vm/command_builders.py
+++ b/test/test_vm/command_builders.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pygerber.builder.rvmc import RvmcBuilder
+from pygerber.vm import RVMC
+from pygerber.vm.commands import Command, EndLayer, Shape, StartLayer
+from pygerber.vm.commands.paste import PasteLayer
+from pygerber.vm.types import Box, LayerID, Vector
+
+
+def make_main_layer(box: Optional[Box], origin: Optional[Vector] = None) -> StartLayer:
+    return StartLayer(
+        id=LayerID(id="%main%"), box=box, origin=origin or Vector(x=0, y=0)
+    )
+
+
+def make_layer(
+    id_: str, box: Optional[Box], origin: Optional[Vector] = None
+) -> StartLayer:
+    return StartLayer(id=LayerID(id=id_), box=box, origin=origin or Vector(x=0, y=0))
+
+
+def make_rectangle_in_center_fixed_canvas() -> list[Command]:
+    return [
+        make_main_layer(
+            Box.from_center_width_height((5, 5), 15, 10), origin=Vector(x=5, y=5)
+        ),
+        Shape.new_rectangle((5, 5), 2, 1, is_negative=False),
+        EndLayer(),
+    ]
+
+
+def make_obround_horizontal_in_center_fixed_canvas() -> list[Command]:
+    return [
+        make_main_layer(Box.from_center_width_height((0, 0), 5, 5)),
+        Shape.new_obround((0, 1), 2, 1, is_negative=False),
+        Shape.new_rectangle((0, -1), 2, 1, is_negative=False),
+        EndLayer(),
+    ]
+
+
+def make_obround_vertical_in_center_fixed_canvas() -> list[Command]:
+    return [
+        make_main_layer(Box.from_center_width_height((0, 0), 5, 5)),
+        Shape.new_obround((-1, 0), 1, 2, is_negative=False),
+        Shape.new_rectangle((1, 0), 1, 2, is_negative=False),
+        EndLayer(),
+    ]
+
+
+def make_circle_in_center_fixed_canvas() -> list[Command]:
+    return [
+        make_main_layer(
+            Box.from_center_width_height((5, 5), 15, 10), origin=Vector(x=5, y=5)
+        ),
+        Shape.new_circle((5, 5), 2, is_negative=False),
+        EndLayer(),
+    ]
+
+
+def make_circle_over_circle_in_center_fixed_canvas() -> list[Command]:
+    return [
+        make_main_layer(Box.from_center_width_height((5, 5), 15, 10)),
+        Shape.new_circle((5, 5), 2, is_negative=False),
+        Shape.new_circle((5, 5), 1, is_negative=True),
+        EndLayer(),
+    ]
+
+
+def make_paste_circle_over_circle_in_center_fixed_canvas() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer(box=Box.from_center_width_height((0, 0), 15, 10)) as layer:
+        with layer.layer("D11") as d11:
+            d11.circle((0, 0), 2, is_negative=False)
+            d11.circle((0, 0), 1, is_negative=True)
+
+        layer.paste(d11, (0, 0), is_negative=False)
+
+    return builder.get_rvmc()
+
+
+def make_paste_circle_over_paste_circle_in_center_dynamic_canvas() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer() as layer:
+        with layer.layer("D10") as d10:
+            d10.circle((0, 0), 2, is_negative=False)
+        with layer.layer("D11") as d11:
+            d11.circle((0, 0), 1, is_negative=False)
+
+        layer.paste(d10, (0, 0), is_negative=False)
+        layer.paste(d11, (0, 0), is_negative=True)
+
+    return builder.get_rvmc()
+
+
+def make_paste_rectangle_in_center_fixed_canvas() -> list[Command]:
+    return [
+        make_main_layer(Box.from_center_width_height((5, 5), 15, 10), Vector(x=5, y=5)),
+        make_layer(
+            "rect", Box.from_center_width_height((0, 0), 5, 5), Vector(x=0, y=0)
+        ),
+        Shape.new_rectangle((0, 0), 2, 1, is_negative=False),
+        EndLayer(),
+        Shape.new_rectangle((5, 5), 3, 2, is_negative=False),
+        Shape.new_rectangle((5, 5), 2.8, 1.8, is_negative=True),
+        PasteLayer.new("rect", (5, 5)),
+        EndLayer(),
+    ]
+
+
+def make_paste_negative_rectangle_in_center_fixed_canvas() -> list[Command]:
+    return [
+        make_main_layer(Box.from_center_width_height((5, 5), 15, 10), Vector(x=5, y=5)),
+        make_layer("rect", Box.from_center_width_height((0, 0), 5, 5)),
+        Shape.new_rectangle((0, 0), 2, 1, is_negative=False),
+        EndLayer(),
+        Shape.new_rectangle((5, 5), 3, 2, is_negative=False),
+        PasteLayer.new("rect", (5, 5), is_negative=True),
+        EndLayer(),
+    ]
+
+
+def make_intersecting_rectangles_dynamic_canvas() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer() as layer:
+        layer.rectangle((0, 0), 1, 2, is_negative=False)
+        layer.rectangle((0, 0), 2, 1, is_negative=False)
+
+    return builder.get_rvmc()
+
+
+def make_intersecting_rectangles_2_dynamic_canvas() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer() as layer:
+        layer.rectangle((0, 0), 1, 2, is_negative=False)
+        layer.rectangle((0.5, 0.5), 2, 1, is_negative=False)
+
+    return builder.get_rvmc()
+
+
+def make_intersecting_rectangle_circle() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer() as layer:
+        layer.rectangle((0, 0), 1, 4, is_negative=False)
+        layer.circle((0.5, 0.5), 2, is_negative=False)
+
+    return builder.get_rvmc()
+
+
+def make_intersecting_circle_circle() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer() as layer:
+        layer.circle((10, 10), 10, is_negative=False)
+        layer.circle((5, 5), 10, is_negative=False)
+
+    return builder.get_rvmc()
+
+
+def make_intersecting_circle_circle_negative() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer() as layer:
+        layer.circle((10, 10), 10, is_negative=False)
+        layer.circle((5, 5), 10, is_negative=True)
+
+    return builder.get_rvmc()
+
+
+def make_intersecting_cross_0_0_circle_5_5() -> RVMC:
+    builder = RvmcBuilder()
+    with builder.layer() as layer:
+        layer.cross((0, 0), 15, 20, 1, is_negative=False)
+        layer.circle((5, 5), 5, is_negative=False)
+
+    return builder.get_rvmc()

--- a/test/test_vm/test_shapely.py
+++ b/test/test_vm/test_shapely.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Sequence
+
+from pygerber.vm import RVMC
+from pygerber.vm.commands import Command
+from pygerber.vm.shapely import ShapelyVirtualMachine
+from pygerber.vm.shapely.vm import ShapelyResult
+from test.conftest import TEST_DIRECTORY
+from test.test_vm.command_builders import (
+    make_circle_in_center_fixed_canvas,
+    make_circle_over_circle_in_center_fixed_canvas,
+    make_intersecting_circle_circle,
+    make_intersecting_circle_circle_negative,
+    make_intersecting_cross_0_0_circle_5_5,
+    make_intersecting_rectangle_circle,
+    make_intersecting_rectangles_2_dynamic_canvas,
+    make_intersecting_rectangles_dynamic_canvas,
+    make_obround_horizontal_in_center_fixed_canvas,
+    make_obround_vertical_in_center_fixed_canvas,
+    make_paste_circle_over_circle_in_center_fixed_canvas,
+    make_paste_circle_over_paste_circle_in_center_dynamic_canvas,
+    make_paste_negative_rectangle_in_center_fixed_canvas,
+    make_paste_rectangle_in_center_fixed_canvas,
+    make_rectangle_in_center_fixed_canvas,
+)
+
+OUTPUT_SHAPELY_DIRECTORY = TEST_DIRECTORY / ".vm-output" / "shapely"
+OUTPUT_SHAPELY_DIRECTORY.mkdir(parents=True, exist_ok=True)
+
+
+REFERENCE_ASSETS_DIRECTORY = Path(__file__).parent / "test_shapely_assets"
+
+
+def run(commands: Sequence[Command]) -> ShapelyResult:
+    return run_rvmc(RVMC(commands=commands))
+
+
+def run_rvmc(rvmc: RVMC) -> ShapelyResult:
+    return ShapelyVirtualMachine().run(rvmc)
+
+
+def save(result: ShapelyResult) -> None:
+    caller_name = inspect.stack()[1].function
+    result.save_svg((OUTPUT_SHAPELY_DIRECTORY / caller_name).with_suffix(".svg"))
+
+
+def test_draw_rectangle_in_center() -> None:
+    save(run(make_rectangle_in_center_fixed_canvas()))
+
+
+def test_draw_obround_horizontal_in_center() -> None:
+    save(run(make_obround_horizontal_in_center_fixed_canvas()))
+
+
+def test_draw_obround_vertical_in_center() -> None:
+    save(run(make_obround_vertical_in_center_fixed_canvas()))
+
+
+def test_draw_circle_in_center() -> None:
+    save(run(make_circle_in_center_fixed_canvas()))
+
+
+def test_draw_circle_over_circle_in_center() -> None:
+    save(run(make_circle_over_circle_in_center_fixed_canvas()))
+
+
+def test_paste_circle_over_circle_in_center() -> None:
+    save(run_rvmc(make_paste_circle_over_circle_in_center_fixed_canvas()))
+
+
+def test_paste_circle_over_paste_circle_in_center() -> None:
+    save(run_rvmc(make_paste_circle_over_paste_circle_in_center_dynamic_canvas()))
+
+
+def test_paste_rectangle_in_center() -> None:
+    save(run(make_paste_rectangle_in_center_fixed_canvas()))
+
+
+def test_paste_negative_rectangle_in_center() -> None:
+    save(run(make_paste_negative_rectangle_in_center_fixed_canvas()))
+
+
+def test_intersecting_rectangles_dynamic_canvas() -> None:
+    save(run_rvmc(make_intersecting_rectangles_dynamic_canvas()))
+
+
+def test_intersecting_rectangles_2_dynamic_canvas() -> None:
+    save(run_rvmc(make_intersecting_rectangles_2_dynamic_canvas()))
+
+
+def test_intersecting_rectangle_circle() -> None:
+    save(run_rvmc(make_intersecting_rectangle_circle()))
+
+
+def test_intersecting_circle_circle() -> None:
+    save(run_rvmc(make_intersecting_circle_circle()))
+
+
+def test_intersecting_circle_circle_negative() -> None:
+    save(run_rvmc(make_intersecting_circle_circle_negative()))
+
+
+def test_intersecting_cross_0_0_circle_5_5() -> None:
+    save(run_rvmc(make_intersecting_cross_0_0_circle_5_5()))

--- a/test/test_vm/test_shapely.py
+++ b/test/test_vm/test_shapely.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
-from typing import Sequence
+from typing import Iterable, Sequence
 
 from pygerber.vm import RVMC
 from pygerber.vm.commands import Command
+from pygerber.vm.commands.layer import EndLayer
+from pygerber.vm.commands.shape import Shape
 from pygerber.vm.shapely import ShapelyVirtualMachine
 from pygerber.vm.shapely.vm import ShapelyResult
+from pygerber.vm.types.box import Box
 from test.conftest import TEST_DIRECTORY
+from test.gerberx3.test_builder.test_rvmc import (
+    build_main_origin_x_y_layer_origin_x_y_paste_x_y,
+    build_main_origin_x_y_layer_origin_x_y_paste_x_y_no_main_origin_mark,
+)
 from test.test_vm.command_builders import (
     make_circle_in_center_fixed_canvas,
     make_circle_over_circle_in_center_fixed_canvas,
@@ -18,6 +25,7 @@ from test.test_vm.command_builders import (
     make_intersecting_rectangle_circle,
     make_intersecting_rectangles_2_dynamic_canvas,
     make_intersecting_rectangles_dynamic_canvas,
+    make_main_layer,
     make_obround_horizontal_in_center_fixed_canvas,
     make_obround_vertical_in_center_fixed_canvas,
     make_paste_circle_over_circle_in_center_fixed_canvas,
@@ -105,3 +113,375 @@ def test_intersecting_circle_circle_negative() -> None:
 
 def test_intersecting_cross_0_0_circle_5_5() -> None:
     save(run_rvmc(make_intersecting_cross_0_0_circle_5_5()))
+
+
+class TestCWArc:
+    def axes(self) -> Iterable[Shape]:
+        yield Shape.new_rectangle((0, 0), 15, 0.1, is_negative=False)
+        yield Shape.new_rectangle((0, 0), 0.1, 15, is_negative=False)
+
+    def template(self, *arc: Shape) -> Sequence[Command]:
+        return [
+            make_main_layer(Box.from_center_width_height((0, 0), 15, 15)),
+            *self.axes(),
+            *arc,
+            EndLayer(),
+        ]
+
+    # Quarter arcs
+
+    def test_0_90(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((5, 0), (0, -5), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    def test_90_180(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((0, -5), (-5, 0), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    def test_180_270(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((-5, 0), (0, 5), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    def test_270_360(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((0, 5), (5, 0), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    # Half arcs
+
+    def test_0_180(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((5, 0), (-5, 0), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    def test_90_270(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((0, -5), (0, 5), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    def test_180_360(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((-5, 0), (5, 0), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    def test_270_420(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc((0, 5), (0, -5), (0, 0), 1, is_negative=False)
+                ),
+            )
+        )
+
+    # Quarter arcs with 1/8 rotation
+
+    _45_degrees_vector_x = 3.5355339059327378
+
+    def test_45_135(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc(
+                        (self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (-self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    )
+                ),
+            )
+        )
+
+    def test_135_225(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc(
+                        (-self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (-self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    )
+                ),
+            )
+        )
+
+    def test_225_315(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc(
+                        (-self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    )
+                ),
+            )
+        )
+
+    def test_315_405(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc(
+                        (self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    )
+                ),
+            )
+        )
+
+    def test_full_circle_with_quarter_arcs(self) -> None:
+        save(
+            run(
+                self.template(
+                    Shape.new_cw_arc(
+                        (self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (-self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    ),
+                    Shape.new_cw_arc(
+                        (-self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (-self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    ),
+                    Shape.new_cw_arc(
+                        (-self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    ),
+                    Shape.new_cw_arc(
+                        (self._45_degrees_vector_x, self._45_degrees_vector_x),
+                        (self._45_degrees_vector_x, -self._45_degrees_vector_x),
+                        (0, 0),
+                        1,
+                        is_negative=False,
+                    ),
+                ),
+            )
+        )
+
+
+class TestPasteWithOffset:
+    def test_main_origin_0_0_layer_origin_0_0_paste_0_0_expect_circle_at_0_0(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0), layer_origin=(0, 0), paste=(0, 0)
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_0_0_paste_2_2_expect_circle_at_2_2(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0), layer_origin=(0, 0), paste=(2, 2)
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_0_0_paste_8_8_expect_circle_at_8_8(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0), layer_origin=(0, 0), paste=(8, 8)
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_2_2_paste_0_0_expect_circle_at_neg_2_neg_2(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0), layer_origin=(2, 2), paste=(0, 0)
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_2_2_paste_2_2_expect_circle_at_0_0(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0), layer_origin=(2, 2), paste=(2, 2)
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_8_8_paste_8_8_expect_circle_at_0_0(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0), layer_origin=(8, 8), paste=(8, 8)
+                ),
+            )
+        )
+
+    def test_main_origin_2_2_layer_origin_0_0_paste_0_0_expect_circle_at_0_0(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(2, 2), layer_origin=(0, 0), paste=(0, 0)
+                ),
+            )
+        )
+
+    def test_main_origin_2_2_layer_origin_0_0_paste_2_2_expect_circle_at_2_2(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(2, 2), layer_origin=(0, 0), paste=(2, 2)
+                ),
+            )
+        )
+
+    def test_main_origin_2_2_layer_origin_2_2_paste_0_0_expect_circle_at_neg_2_neg_2(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(2, 2), layer_origin=(2, 2), paste=(0, 0)
+                ),
+            )
+        )
+
+    def test_main_origin_2_2_layer_origin_2_2_paste_2_2_expect_circle_at_0_0(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(2, 2), layer_origin=(2, 2), paste=(2, 2)
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_0_0_paste_0_0_circle_at_2_2_expect_circle_at_2_2(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0),
+                    layer_origin=(0, 0),
+                    paste=(0, 0),
+                    circle_at=(2, 2),
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_0_0_paste_2_2_circle_at_2_2_expect_circle_at_4_4(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0),
+                    layer_origin=(0, 0),
+                    paste=(2, 2),
+                    circle_at=(2, 2),
+                ),
+            )
+        )
+
+    def test_main_origin_0_0_layer_origin_2_2_paste_2_2_circle_at_2_2_expect_circle_at_2_2(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(0, 0),
+                    layer_origin=(2, 2),
+                    paste=(2, 2),
+                    circle_at=(2, 2),
+                ),
+            )
+        )
+
+    def test_main_origin_neg_8_neg_8_layer_origin_4_4_paste_2_2_circle_at_2_2_expect_circle_at_0_0(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y(
+                    main_origin=(-8, -8),
+                    layer_origin=(4, 4),
+                    paste=(2, 2),
+                    circle_at=(2, 2),
+                ),
+            )
+        )
+
+    def test_main_origin_neg_8_neg_8_layer_origin_4_4_paste_2_2_circle_at_2_2_expect_circle_at_0_0_no_main_origin_mark(
+        self,
+    ) -> None:
+        save(
+            run_rvmc(
+                build_main_origin_x_y_layer_origin_x_y_paste_x_y_no_main_origin_mark(
+                    main_origin=(-8, -8),
+                    layer_origin=(4, 4),
+                    paste=(2, 2),
+                    circle_at=(2, 2),
+                ),
+            )
+        )


### PR DESCRIPTION
This pull request introduces new implementation of `VirtualMachine` interface, `ShapelyVirtualMachine` utilizing `shapely` library for generation of complex geometry. Alongside the implementation, unit and e2e tests are included. Currently `ShapelyResult` allows only SVG export. 
Overall performance of implementation is above expectations, seems to be very close to what `pillow` based implementation offers. On Ryzen 9 7950X rendering of [A64-OlinuXino_Rev_G-B_Cu.gbr](https://github.com/Argmaster/pygerber/blob/main/test/assets/gerberx3/A64_OLinuXino_rev_G/A64-OlinuXino_Rev_G-B_Cu.gbr) takes around 20s, including parsing and compilation to RVMC. However I must admit that this is still like 10x slower than Reference Gerber Viewer, no idea what kind of black magic they are using to render this so quickly 😄 

Here is sample output:

<p align="center">
<img  width="500" src=https://github.com/user-attachments/assets/a5a99999-59b2-46bc-befe-2eeee82bc6ad />
</p>

Also, output is much cleaner than with masking approach used in drawsvg based rendering in PyGerber 2.4.1. Still, drawsvg backend will be likely implemented, since it is so easy to do so.

This virtual machine is not enabled by default in PyGerber to avoid depending on shapely and GEOS. It can be installed with `shapely` extras:

```bash
pip install pygerber[shapely]
```

Also, it is sick how easy it is to implement new virtual machines, VM code itself is like 370 lines.